### PR TITLE
Refactor to use new portal

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 160

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,5 @@
 Copyright (c) 2014, Olli Jarva <olli@jarva.fi>
+Copyright (c) 2023, Janne Summanen <janne.summanen@proton.me>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without 

--- a/README.rst
+++ b/README.rst
@@ -16,47 +16,138 @@ Usage:
 
 ::
 
+  from datetime import datetime, timezone
   import helen_electricity_usage
-  helen = helen_electricity_usage.Helen(username, password, metering_point_number, customer_number)
+  helen = helen_electricity_usage.Helen(username, password, delivery_site_id)
   helen.login()
-  print helen.get_date("20141225")
+  begin = datetime(year=2023, month=1, day=1, hour=0, minute=0, second=0, tzinfo=timezone.utc)
+  end = datetime(year=2023, month=1, day=1, hour=23, minute=59, second=59, tzinfo=timezone.utc)
+  print(helen.get_electricity(begin, end))
 
 To obtain username and password, register using `web interface
-<https://www2.helen.fi/raportointi/>`_ (Flash and paper invoice is
-required). After registering and signing in, metering point number is
-available on the top-right corner.
+<https://www.helen.fi/kirjautuminen>`_ (paper invoice is required).
+After registering and signing in, delivery site id is available on the URL of Sähkö/Electricity page as well as on the page
+under Käyttöpaikka/Consumption location
+
+::
+  https://web.omahelen.fi/personal/reports/electricity-consumption?location=<delivery_site_id>&resolution=month&date=2023-01-01
+
 
 Sample output (python dictionary):
 
 ::
 
- [{'month': 10,
-  'hour': 0,
-  'year': 2020,
-  'waterFlowPrice': 0.0,
-  'temperature': 11.8,
-  'milestones': [],
-  'value': 0.92999,
-  'day': 1,
-  'teleEuro': 0.0,
-  'status': 30,
-  'telePrediction': 0.0},
- {'month': 10,
-  'hour': 1,
-  'year': 2020,
-  'waterFlowPrice': 0.0,
-  'temperature': 11.2,
-  'milestones': [],
-  'value': 0.66,
-  'day': 1,
-  'teleEuro': 0.0,
-  'status': 30,
-  'telePrediction': 0.0},
-  ...
- ]
+  {
+    "intervals": {
+      "electricity": [
+        {
+          "start": "2022-12-24T00:00:00+00:00",
+          "stop": "2022-12-24T23:59:59+00:00",
+          "resolution_s": 3600,
+          "resolution": "hour",
+          "unit": "kWh",
+          "measurements": [
+            {
+              "value": 0.11,
+              "status": "valid"
+            },
+            {
+              "value": 0.12,
+              "status": "valid"
+            },
+            {
+              "value": 0.11,
+              "status": "valid"
+            },
+            {
+              "value": 0.12,
+              "status": "valid"
+            },
+            {
+              "value": 0.11,
+              "status": "valid"
+            },
+            {
+              "value": 0.12,
+              "status": "valid"
+            },
+            {
+              "value": 0.79,
+              "status": "valid"
+            },
+            {
+              "value": 0.35,
+              "status": "valid"
+            },
+            {
+              "value": 0.28,
+              "status": "valid"
+            },
+            {
+              "value": 0.26,
+              "status": "valid"
+            },
+            {
+              "value": 0.21,
+              "status": "valid"
+            },
+            {
+              "value": 0.26,
+              "status": "valid"
+            },
+            {
+              "value": 1.08,
+              "status": "valid"
+            },
+            {
+              "value": 1.03,
+              "status": "valid"
+            },
+            {
+              "value": 0.39,
+              "status": "valid"
+            },
+            {
+              "value": 0.47,
+              "status": "valid"
+            },
+            {
+              "value": 3.33,
+              "status": "valid"
+            },
+            {
+              "value": 3.83,
+              "status": "valid"
+            },
+            {
+              "value": 1.19,
+              "status": "valid"
+            },
+            {
+              "value": 0.43,
+              "status": "valid"
+            },
+            {
+              "value": 0.4,
+              "status": "valid"
+            },
+            {
+              "value": 0.32,
+              "status": "valid"
+            },
+            {
+              "value": 0.13,
+              "status": "valid"
+            },
+            {
+              "value": 0.12,
+              "status": "valid"
+            }
+          ]
+        }
+      ]
+    }
+  }
 
-There is no way to check whether data for specific date is available. If
-data is not available, all fields are provided, but values are 0.0.
-There is no way to distinct between missing data and hours with no
-electricity consumption. Usually the data is available next day, but
-that is not guaranteed.
+Missing data can be identified from the status being 'invalid' and value is 0.0.
+Usually the data is available next day, but that is not guaranteed.

--- a/helen_electricity_usage/__init__.py
+++ b/helen_electricity_usage/__init__.py
@@ -1,63 +1,161 @@
-from bs4 import BeautifulSoup
-from requests.auth import HTTPBasicAuth
+from datetime import datetime, timezone, timedelta
+from typing import Optional
 import json
+import logging
 import requests
 import sys
-import time
+import xml.etree.ElementTree as ET
 
 
-class Helen(object):
+class Helen:
+    def __init__(self, username: str, password: str, delivery_site_id: int, session: requests.Session = None) -> None:
+        """ Api Client to communicate with Helen portal API
 
-    def __init__(self, username, password, metering_point_number, customer_number):
+        :param str username: Helen portal username. Usually email address
+        :param str password: The users password to Helen portal
+        :param int delivery_site_id: Helen delivery site id user has access to
+        :param requests.Session session: Requests session to use. If not provided one will be created
+        """
         self.username = username
         self.password = password
-        self.metering_point_number = metering_point_number
-        self.customer_number = customer_number
-        self.session = requests.Session()
-        self.session_time = int(time.time() * 1000)
+        self.delivery_site_id = delivery_site_id
+        self.session = requests.Session() if session is None else session
+        self.access_token = None
+        self.login_url = None
+        self.log = logging.getLogger('HelenApiClient')
 
-    def login(self):
-        resp = self.session.get("https://www2.helen.fi/mobiili/")
-        loginpage = BeautifulSoup(resp.text, "html.parser")
-        post_url = "https://login.helen.fi" + loginpage.find("div", "loginitem").find("form").get("action")
-        resp = self.session.post(post_url, data={"username": self.username, "password": self.password, "method": "password.2"})
-        resp.raise_for_status()
-        authpage = BeautifulSoup(resp.text, "html.parser")
-        loginform = authpage.find("div", "loginbutton").find("form")
-        shibboleth_url = loginform.get("action")
-        post_data = {}
-        for item in loginform.find_all("input"):
-            if item.get("name") is None:
-                continue
-            post_data[item.get("name")] = item.get("value")
+    def _parse_js_redirect_form(self, content: str) -> tuple:
+        """ Parse JS based redirect from <noscript> forms in Helen login flow.
 
-        login_page = self.session.post(shibboleth_url, data=post_data)
+        :param str content: Page HTML as string
+        :return: Tuple containing form action url, code and state
+        :rtype: tuple[str]
+        """
+        root = ET.fromstring(content)
+        form = root.find(".//{http://www.w3.org/1999/xhtml}form[@action][@id='form']")
+        action = form.get("action")
+        self.log.debug("Parsed return URL from form as '%s'" % action)
+        code = form.find(".//{http://www.w3.org/1999/xhtml}input[@name='code']")
+        state = form.find(".//{http://www.w3.org/1999/xhtml}input[@name='state']")
+        if state is None or code is None:
+            raise Exception("Something went wrong while parsing state and code")
+        return (action, code.get("value"), state.get("value"))
 
-    def get_session_time(self):
-        self.session_time += 1
-        return self.session_time
+    def scrape_login_url(self) -> str:
+        """ Scrape Helen login page for the actual openid login URL.
 
-    def get_date(self, date):
-        response = self.session.get("https://www2.helen.fi/api/meteringpoints/0/%s/series?enddate=%s&numberofmonths=12&numberofyears=2&resolution=DAYS_AS_HOURS&selector=value,status,day,month,year,hour,milestones(title,note,timestamp(date,month,year)),temperature,prediction,telePrediction,budget,teleEuro,waterFlowPrice" % (self.metering_point_number, date), auth=('%s/MainUserElec' % self.customer_number, 'N/A'))
-        if response.status_code != 200:
-            raise ValueError("Server returned %s" % response.status_code)
-        if len(response.history) > 0:
-            raise ValueError("Request was redirected. Probably authorization issue - is metering point number set properly?")
-        try:
-            return json.loads(response.text)
-        except:
-            print (response.text)
-            raise ValueError("Unable to parse response JSON")
+        The URL to Helen login contains OpenID client and application IDs that change from request to request.
+        Start from the TupasLoginFrame to dig for the required URL for login.
+
+        :return: the URL to login to Helen Oma portal
+        :rtype: str
+        """
+        login_host = "login.helen.fi"
+
+        # Start by getting TupasLoginFrame (UI entrypoint for login)
+        res = self.session.get("https://www.helen.fi/hcc/TupasLoginFrame?service=account&locale=fi")
+        self.log.debug("TupasLoginFrame response status: %s", res.status_code)
+        res.raise_for_status()
+
+        # find login form address from the TupasLoginFrame
+        res_element = ET.fromstring(res.text)
+        form = res_element.findall(".//form[@action]")
+        login_form_url = form[0].get("action")
+        self.log.debug("Login form is at '%s'", login_form_url)
+
+        # Get the login form
+        res = self.session.post(login_form_url)
+        self.log.debug("login_form_url response status: %s", res.status_code)
+        res.raise_for_status()
+
+        # Find the authorization endpoint from the login form
+        res_element = ET.fromstring(res.text)
+        form = res_element.findall(".//{http://www.w3.org/1999/xhtml}form[@action]")
+        self.login_url = f"https://{login_host}{form[0].get('action')}"
+        self.log.info("Login url is '%s'", self.login_url)
+
+        return self.login_url
+
+    def login(self, login_url: Optional[str] = None) -> None:
+        """ Log in to Helen portal and return the authorization token
+
+        :param str login_url: Override for the one time login URL
+        """
+        if login_url is None:
+            login_url = self.scrape_login_url() if self.login_url is None else self.login_url
+
+        res = self.session.post(login_url, data={"username": self.username, "password": self.password})
+        if res.status_code != 200:
+            raise Exception("Login failed. Most likely unauthorized")
+
+        # After successful login one needs to click on a button to continue or let the js do it for you.
+        action, code, state = self._parse_js_redirect_form(res.text)
+
+        # Use the parsed url and params to continue
+        res = self.session.get(action, params={"code": code, "state": state})
+        if res.status_code != 200:
+            raise Exception("Something went wrong with login :(")
+
+        # Hard coded manual redirect from https://www.helen.fi/authResponse
+        res = self.session.get("https://api.omahelen.fi/v2/login", params={"redirect": "https://web.omahelen.fi/?lang=fi", "lang": "fi"})
+
+        # Continue with new code and state.
+        action, code, state = self._parse_js_redirect_form(res.text)
+        res = self.session.get(action, params={"code": code, "state": state})
+
+        self.access_token = self.session.cookies.get("access-token")
+
+    def get_electricity(self, begin: datetime, end: datetime, resolution: str = "hour", allow_transfer: bool = True) -> dict:
+        """ Get Electricity consumption metrics from Helen API
+
+        The metrics are usually delayed for a day or so.
+
+        :param datetime begin: Time to start the electricity report from. Aware datetime with UTC timezone
+        :param datetime end: Time to end the electricity report to. Aware datetime with UTC timezone
+        :param str resolution: The resolution or size of buckets in the report.
+        :param bool allow_transfer: Unknown upstream parameter.
+        :return: dictionary response from Helen API
+        :rtype: dict
+        """
+        if self.access_token is None:
+            raise Exception("Invalid state: Helen must be logged in before calling get_electricity()")
+
+        res = self.session.get(
+            "https://api.omahelen.fi/v8/measurements/electricity",
+            params={
+                "begin": begin.isoformat(timespec="seconds").replace("+00:00", "Z"),
+                "end": end.isoformat(timespec="seconds").replace("+00:00", "Z"),
+                "resolution": resolution,
+                "delivery_site_id": self.delivery_site_id,
+                "allow_transfer": allow_transfer,
+            },
+            headers={
+                "Authorization": f"Bearer {self.access_token}",
+                "Accept": "application/json"
+            }
+        )
+        return res.json()
 
 
 def main(args):
-    if len(args) != 4:
-        print("Mandatory parameters: username password metering_point_number customer_number")
+    logging.basicConfig(stream=sys.stdout, level=logging.WARNING)
+
+    if len(args) != 3:
+        print("Mandatory parameters: username password delivery_site_id")
         return 2
-    helen = Helen(args[0], args[1], args[2], args[3])
+
+    helen = Helen(username=args[0], password=args[1], delivery_site_id=args[2])
     helen.login()
-    print((helen.get_date("20151204")))
+
+    print("Requesting electricity report")
+    now = datetime.now(tz=timezone.utc)
+    one_day = timedelta(days=1)
+    yesterday = now - one_day
+    begin = yesterday.replace(hour=0, minute=0, second=0)
+    end = yesterday.replace(hour=23, minute=59, second=59)
+    print(json.dumps(helen.get_electricity(begin, end), indent=4))
     return 0
+
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-beautifulsoup4==4.4.1
-requests==2.20.0
+requests~=2.28

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='helen_electricity_usage',
-    version='0.1.1',
+    version='0.2.0',
     description='Small library for scraping electricity usage information from Helsingin Energia website',
     long_description=long_description,
     url='https://github.com/ojarva/python-helen-electricity-usage',
@@ -24,11 +24,10 @@ setup(
         'Topic :: Internet',
         'License :: OSI Approved :: BSD License',
 
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     keywords='electricity helen',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     keywords='electricity helen',
     packages=["helen_electricity_usage"],
-    install_requires=['requests>=2.5.1', 'beautifulsoup4>=4.4.1'],
+    install_requires=['requests~=2.28'],
 
     extras_require={
         'dev': ['twine', 'wheel'],


### PR DESCRIPTION
Helen Tone/Sävel service was recently discontinued. It has been replaced with new My Helen App/portal.

As @mvcaaa reported in #4 the library was completely broken. This PR aims to refactor the authentication flow and data collection to work with the new Helen portal.

I'm not sure how solid the implementation is but at least I was able to pull some data out from the service. 